### PR TITLE
Fix Image::fromString to support PNG and WebP files

### DIFF
--- a/src/Format/JPEG.php
+++ b/src/Format/JPEG.php
@@ -81,22 +81,12 @@ class JPEG extends Image
      */
     public static function fromString($string)
     {
-        $imageSize = getimagesizefromstring($string);
-        if ($imageSize === false) {
-            throw new \Exception('Invalid image data');
-        }
-
-        $width = $imageSize[0];
-        $height = $imageSize[1];
-
         $stream = fopen('php://temp', 'r+');
         fwrite($stream, $string);
         rewind($stream);
 
         $jpeg = self::fromStream($stream);
-
-        $jpeg->width = $width;
-        $jpeg->height = $height;
+        $jpeg->setSizeFromString($string);
 
         return $jpeg;
     }
@@ -121,6 +111,8 @@ class JPEG extends Image
      *
      * @return self
      * @throws \Exception
+     *
+     * @todo calculate and set image size
      */
     public static function fromStream($fileHandle)
     {
@@ -206,18 +198,8 @@ class JPEG extends Image
             throw new \Exception(sprintf('Could not open file %s', $filename));
         }
 
-        $imageSize = getimagesize($filename);
-        if ($imageSize === false) {
-            throw new \Exception(sprintf('Could not get image size for %s', $filename));
-        }
-
-        $width = $imageSize[0];
-        $height = $imageSize[1];
-
         $jpeg = self::fromStream($fileHandle);
-
-        $jpeg->width = $width;
-        $jpeg->height = $height;
+        $jpeg->setSizeFromFile($filename);
 
         return $jpeg;
     }

--- a/src/Format/JPEG.php
+++ b/src/Format/JPEG.php
@@ -81,11 +81,24 @@ class JPEG extends Image
      */
     public static function fromString($string)
     {
+        $imageSize = getimagesizefromstring($string);
+        if ($imageSize === false) {
+            throw new \Exception('Invalid image data');
+        }
+
+        $width = $imageSize[0];
+        $height = $imageSize[1];
+
         $stream = fopen('php://temp', 'r+');
         fwrite($stream, $string);
         rewind($stream);
 
-        return self::fromStream($stream);
+        $jpeg = self::fromStream($stream);
+
+        $jpeg->width = $width;
+        $jpeg->height = $height;
+
+        return $jpeg;
     }
 
     /**
@@ -189,12 +202,24 @@ class JPEG extends Image
     public static function fromFile($filename)
     {
         $fileHandle = @fopen($filename, 'rb');
-
         if (!$fileHandle) {
             throw new \Exception(sprintf('Could not open file %s', $filename));
         }
 
-        return self::fromStream($fileHandle);
+        $imageSize = getimagesize($filename);
+        if ($imageSize === false) {
+            throw new \Exception(sprintf('Could not get image size for %s', $filename));
+        }
+
+        $width = $imageSize[0];
+        $height = $imageSize[1];
+
+        $jpeg = self::fromStream($fileHandle);
+
+        $jpeg->width = $width;
+        $jpeg->height = $height;
+
+        return $jpeg;
     }
 
     /**

--- a/src/Format/PNG.php
+++ b/src/Format/PNG.php
@@ -101,7 +101,20 @@ class PNG extends Image
      */
     public static function fromFile($filename)
     {
-        return new self(file_get_contents($filename));
+        $imageSize = getimagesize($filename);
+        if ($imageSize === false) {
+            throw new \Exception(sprintf('Could not get image size for %s', $filename));
+        }
+
+        $width = $imageSize[0];
+        $height = $imageSize[1];
+
+        $png = new self(file_get_contents($filename));
+
+        $png->width = $width;
+        $png->height = $height;
+
+        return $png;
     }
 
     /**
@@ -111,7 +124,20 @@ class PNG extends Image
      */
     public static function fromString($string)
     {
-        return new self($string);
+        $imageSize = getimagesizefromstring($string);
+        if ($imageSize === false) {
+            throw new \Exception('Invalid PNG data');
+        }
+
+        $width = $imageSize[0];
+        $height = $imageSize[1];
+
+        $png = new self($string);
+
+        $png->width = $width;
+        $png->height = $height;
+
+        return $png;
     }
 
     /**

--- a/src/Format/PNG.php
+++ b/src/Format/PNG.php
@@ -105,6 +105,16 @@ class PNG extends Image
     }
 
     /**
+     * @param $string
+     *
+     * @return PNG
+     */
+    public static function fromString($string)
+    {
+        return new self($string);
+    }
+
+    /**
      * @param string $contents
      *
      * @throws \Exception

--- a/src/Format/PNG.php
+++ b/src/Format/PNG.php
@@ -40,6 +40,8 @@ class PNG extends Image
         }
 
         $this->chunks = $this->getChunksFromContents($contents);
+
+        $this->setSizeFromString($contents);
     }
 
     /**
@@ -101,20 +103,12 @@ class PNG extends Image
      */
     public static function fromFile($filename)
     {
-        $imageSize = getimagesize($filename);
-        if ($imageSize === false) {
-            throw new \Exception(sprintf('Could not get image size for %s', $filename));
+        $contents = file_get_contents($filename);
+        if ($contents === false) {
+            throw new \Exception(sprintf('Could not open file %s', $filename));
         }
 
-        $width = $imageSize[0];
-        $height = $imageSize[1];
-
-        $png = new self(file_get_contents($filename));
-
-        $png->width = $width;
-        $png->height = $height;
-
-        return $png;
+        return new self($contents);
     }
 
     /**
@@ -124,20 +118,7 @@ class PNG extends Image
      */
     public static function fromString($string)
     {
-        $imageSize = getimagesizefromstring($string);
-        if ($imageSize === false) {
-            throw new \Exception('Invalid PNG data');
-        }
-
-        $width = $imageSize[0];
-        $height = $imageSize[1];
-
-        $png = new self($string);
-
-        $png->width = $width;
-        $png->height = $height;
-
-        return $png;
+        return new self($string);
     }
 
     /**

--- a/src/Format/PSD.php
+++ b/src/Format/PSD.php
@@ -4,6 +4,7 @@ namespace CSD\Image\Format;
 
 use CSD\Image\Metadata\Exif;
 use CSD\Image\Metadata\Iptc;
+use CSD\Image\Metadata\UnsupportedException;
 use CSD\Image\Metadata\Xmp;
 use CSD\Image\Image;
 
@@ -70,6 +71,8 @@ class PSD extends Image {
 
     /**
      * Load PSD from string.
+     *
+     * @todo calculate and set image size
      */
     public static function fromString($string)
     {
@@ -96,6 +99,8 @@ class PSD extends Image {
      *
      * @return self
      * @throws \Exception
+     *
+     * @todo calculate and set image size
      */
     public static function fromStream($fileHandle)
     {
@@ -194,7 +199,9 @@ class PSD extends Image {
             throw new \Exception(sprintf('Could not open file %s', $filename));
         }
 
-        return self::fromStream($fileHandle);
+        $psd = self::fromStream($fileHandle);
+        $psd->setSizeFromFile($filename);
+        return $psd;
     }
 
     /**

--- a/src/Format/WebP.php
+++ b/src/Format/WebP.php
@@ -144,8 +144,22 @@ class WebP extends Image
      */
     public static function fromFile($filename)
     {
-        return new self(file_get_contents($filename));
+        $imageSize = getimagesize($filename);
+        if ($imageSize === false) {
+            throw new \Exception(sprintf('Could not get image size for %s', $filename));
+        }
+
+        $width = $imageSize[0];
+        $height = $imageSize[1];
+
+        $webp = new self(file_get_contents($filename));
+
+        $webp->width = $width;
+        $webp->height = $height;
+
+        return $webp;
     }
+
 
     /**
      * @param $string
@@ -154,7 +168,20 @@ class WebP extends Image
      */
     public static function fromString($string)
     {
-        return new self($string);
+        $imageSize = getimagesizefromstring($string);
+        if ($imageSize === false) {
+            throw new \Exception('Invalid WebP data');
+        }
+
+        $width = $imageSize[0];
+        $height = $imageSize[1];
+
+        $webp = new self($string);
+
+        $webp->width = $width;
+        $webp->height = $height;
+
+        return $webp;
     }
 
     /**

--- a/src/Format/WebP.php
+++ b/src/Format/WebP.php
@@ -144,8 +144,17 @@ class WebP extends Image
      */
     public static function fromFile($filename)
     {
-        // var_dump($filename);
         return new self(file_get_contents($filename));
+    }
+
+    /**
+     * @param $string
+     *
+     * @return PNG
+     */
+    public static function fromString($string)
+    {
+        return new self($string);
     }
 
     /**

--- a/src/Format/WebP.php
+++ b/src/Format/WebP.php
@@ -47,6 +47,8 @@ class WebP extends Image
         if (!$this->isExtendedFormat()) {
 //            throw new \Exception('Only extended WebP format is supported');
         }
+
+        $this->setSizeFromString($contents);
     }
 
     /**
@@ -144,20 +146,12 @@ class WebP extends Image
      */
     public static function fromFile($filename)
     {
-        $imageSize = getimagesize($filename);
-        if ($imageSize === false) {
-            throw new \Exception(sprintf('Could not get image size for %s', $filename));
+        $contents = file_get_contents($filename);
+        if ($contents === false) {
+            throw new \Exception(sprintf('Could not open file %s', $filename));
         }
 
-        $width = $imageSize[0];
-        $height = $imageSize[1];
-
-        $webp = new self(file_get_contents($filename));
-
-        $webp->width = $width;
-        $webp->height = $height;
-
-        return $webp;
+        return new self($contents);
     }
 
 
@@ -168,20 +162,7 @@ class WebP extends Image
      */
     public static function fromString($string)
     {
-        $imageSize = getimagesizefromstring($string);
-        if ($imageSize === false) {
-            throw new \Exception('Invalid WebP data');
-        }
-
-        $width = $imageSize[0];
-        $height = $imageSize[1];
-
-        $webp = new self($string);
-
-        $webp->width = $width;
-        $webp->height = $height;
-
-        return $webp;
+        return new self($string);
     }
 
     /**

--- a/src/Image.php
+++ b/src/Image.php
@@ -210,29 +210,31 @@ abstract class Image implements ImageInterface
      *
      * @return JPEG|WebP|PNG|false
      */
+
     public static function fromString($string)
     {
-        $len = strlen($string);
+        $imageInfo = getimagesizefromstring($string);
 
-        // try JPEG
-        if ($len >= 2) {
-            if (JPEG::SOI === substr($string, 0, 2)) {
-                return JPEG::fromString($string);
-            }
+        if (!$imageInfo) {
+            return false;
         }
 
-        // try WebP
-        if ($len >= 4) {
-            if ('RIFF' === substr($string, 0, 4) && 'WEBP' === substr($string, 8, 4)) {
-                return WebP::fromString($string);
-            }
-        }
+        $width = $imageInfo[0];
+        $height = $imageInfo[1];
+        $mime = $imageInfo['mime'];
 
-        // try PNG
-        if ($len >= 8) {
-            if (PNG::SIGNATURE === substr($string, 0, 8)) {
-                return PNG::fromString($string);
-            }
+        $mimeToClass = [
+            'image/jpeg' => JPEG::class,
+            'image/png'  => PNG::class,
+            'image/webp' => WebP::class,
+        ];
+
+        if (isset($mimeToClass[$mime])) {
+            $class = $mimeToClass[$mime];
+            $image = $class::fromString($string);
+            $image->width = $width;
+            $image->height = $height;
+            return $image;
         }
 
         return false;

--- a/src/Image.php
+++ b/src/Image.php
@@ -198,10 +198,6 @@ abstract class Image implements ImageInterface
         if (!$result) {
             throw new \Exception('Unrecognised file name');
         }
-
-        $size = getimagesize($fileName);
-        $result->width = $size[0];
-        $result->height = $size[1];
         return $result;
     }
 
@@ -219,8 +215,6 @@ abstract class Image implements ImageInterface
             return false;
         }
 
-        $width = $imageInfo[0];
-        $height = $imageInfo[1];
         $mime = $imageInfo['mime'];
 
         $mimeToClass = [
@@ -232,11 +226,26 @@ abstract class Image implements ImageInterface
         if (isset($mimeToClass[$mime])) {
             $class = $mimeToClass[$mime];
             $image = $class::fromString($string);
-            $image->width = $width;
-            $image->height = $height;
             return $image;
         }
 
         return false;
+    }
+
+    protected function setSizeFromFile($fileName)
+    {
+        $imageSize = getimagesize($fileName);
+        if ($imageSize === false) {
+            throw new \Exception(sprintf('Could not get image size for %s', $fileName));
+        }
+        $this->width = $imageSize[0];
+        $this->height = $imageSize[1];
+    }
+
+    protected function setSizeFromString($string)
+    {
+        $size = getimagesizefromstring($string);
+        $this->width = $size[0];
+        $this->height = $size[1];
     }
 }

--- a/tests/Format/JPEGTest.php
+++ b/tests/Format/JPEGTest.php
@@ -49,6 +49,9 @@ class JPEGTest extends \PHPUnit\Framework\TestCase
             throw new \InvalidArgumentException("Invalid method: $method");
         }
 
+        $this->assertInstanceOf(JPEG::class, $jpeg);
+        $this->assertGreaterThan(0, $jpeg->getSize()["width"]);
+
         $xmp = $jpeg->getXmp();
 
         $this->assertInstanceOf(Xmp::class, $xmp);

--- a/tests/Format/JPEGTest.php
+++ b/tests/Format/JPEGTest.php
@@ -51,6 +51,7 @@ class JPEGTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(JPEG::class, $jpeg);
         $this->assertGreaterThan(0, $jpeg->getSize()["width"]);
+        $this->assertGreaterThan(0, $jpeg->getSize()["height"]);
 
         $xmp = $jpeg->getXmp();
 

--- a/tests/Format/PNGTest.php
+++ b/tests/Format/PNGTest.php
@@ -53,6 +53,7 @@ class PNGTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(PNG::class, $png);
         $this->assertGreaterThan(0, $png->getSize()["width"]);
+        $this->assertGreaterThan(0, $png->getSize()["height"]);
 
         $xmp = $png->getXmp();
 

--- a/tests/Format/PNGTest.php
+++ b/tests/Format/PNGTest.php
@@ -51,6 +51,9 @@ class PNGTest extends \PHPUnit\Framework\TestCase
             throw new \InvalidArgumentException("Invalid method: $method");
         }
 
+        $this->assertInstanceOf(PNG::class, $png);
+        $this->assertGreaterThan(0, $png->getSize()["width"]);
+
         $xmp = $png->getXmp();
 
         $this->assertInstanceOf(Xmp::class, $xmp);

--- a/tests/Format/WebPTest.php
+++ b/tests/Format/WebPTest.php
@@ -50,6 +50,7 @@ class WebPTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(WebP::class, $webp);
         $this->assertGreaterThan(0, $webp->getSize()["width"]);
+        $this->assertGreaterThan(0, $webp->getSize()["height"]);
 
         $xmp = $webp->getXmp();
 

--- a/tests/Format/WebPTest.php
+++ b/tests/Format/WebPTest.php
@@ -49,6 +49,7 @@ class WebPTest extends \PHPUnit\Framework\TestCase
         }
 
         $this->assertInstanceOf(WebP::class, $webp);
+        $this->assertGreaterThan(0, $webp->getSize()["width"]);
 
         $xmp = $webp->getXmp();
 

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -30,12 +30,44 @@ class ImageTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers ::fromString
+     * @covers ::getSize
+     */
+    public function testPNGFromString()
+    {
+        $string = \file_get_contents(__DIR__ . '/Fixtures/nometa.png');
+        $image = Image::fromString($string);
+
+        $this->assertInstanceOf(PNG::class, $image);
+        $this->assertSame([
+            'width' => 10,
+            'height' => 10,
+        ], $image->getSize());
+    }
+
+    /**
      * @covers ::fromFile
      * @covers ::getSize
      */
     public function testJPG()
     {
         $image = Image::fromFile(__DIR__ . '/Fixtures/nometa.jpg');
+        $this->assertInstanceOf(JPEG::class, $image);
+        $this->assertSame([
+            'width' => 10,
+            'height' => 10,
+        ], $image->getSize());
+    }
+
+    /**
+     * @covers ::fromString
+     * @covers ::getSize
+     */
+    public function testJPGFromString()
+    {
+        $string = \file_get_contents(__DIR__ . '/Fixtures/nometa.jpg');
+
+        $image = Image::fromString($string);
         $this->assertInstanceOf(JPEG::class, $image);
         $this->assertSame([
             'width' => 10,
@@ -56,6 +88,23 @@ class ImageTest extends \PHPUnit\Framework\TestCase
             'height' => 368,
         ], $image->getSize());
     }
+
+    /**
+     * @covers ::fromString
+     * @covers ::getSize
+     */
+    public function testWebpFromString()
+    {
+        $string = \file_get_contents(__DIR__ . '/Fixtures/simple.webp');
+        $image = Image::fromString($string);
+
+        $this->assertInstanceOf(WebP::class, $image);
+        $this->assertSame([
+            'width' => 550,
+            'height' => 368,
+        ], $image->getSize());
+    }
+
 
     /**
      * @covers ::fromFile


### PR DESCRIPTION
- Add missing fromString methods to PNG and WebP classes
- Update Image::fromString to read image size and MIME type with getimagesizefromstring
- Update and refactor related tests

Fixes #30 

